### PR TITLE
Add Salt to Delegation Terms

### DIFF
--- a/apps/erc20-delegatable-app/components/form-issue-card.tsx
+++ b/apps/erc20-delegatable-app/components/form-issue-card.tsx
@@ -14,8 +14,8 @@ import { useErc20Manager, useErc20PermitNonces } from '@/lib/blockchain'
 import { useContractAutoLoad } from '@/lib/hooks/use-contract-auto-load'
 import { useYupValidationResolver } from '@/lib/useYupValidationResolver'
 import { createDelegation } from '@/lib/utils/create-delegation'
-import { getPermitSignature } from '@/lib/utils/get-permit-signature'
 import { createSalt } from '@/lib/utils/create-salt'
+import { getPermitSignature } from '@/lib/utils/get-permit-signature'
 
 const validationSchema = yup.object({
   to: yup.string().required('Required'),

--- a/apps/erc20-delegatable-app/components/form-issue-card.tsx
+++ b/apps/erc20-delegatable-app/components/form-issue-card.tsx
@@ -15,6 +15,7 @@ import { useContractAutoLoad } from '@/lib/hooks/use-contract-auto-load'
 import { useYupValidationResolver } from '@/lib/useYupValidationResolver'
 import { createDelegation } from '@/lib/utils/create-delegation'
 import { getPermitSignature } from '@/lib/utils/get-permit-signature'
+import { createSalt } from '@/lib/utils/create-salt'
 
 const validationSchema = yup.object({
   to: yup.string().required('Required'),
@@ -62,10 +63,20 @@ export function FormIssueCard() {
 
     const inputTerms = ethers.utils.hexZeroPad(rawUSDCAmount.toHexString(), 32)
 
+    console.log('input terms', inputTerms)
+
+    const salt = await createSalt(signer?.data as ethers.Signer)
+
+    console.log('salt', salt)
+
+    const termsWithSalt = ethers.utils.hexConcat([inputTerms, salt])
+
+    console.log('termsWithSalt', termsWithSalt)
+
     const enforcers = [
       {
         enforcer: contractAllowanceEnforcer.address,
-        terms: inputTerms,
+        terms: termsWithSalt,
       },
     ]
 

--- a/apps/erc20-delegatable-app/lib/utils/create-salt.ts
+++ b/apps/erc20-delegatable-app/lib/utils/create-salt.ts
@@ -1,21 +1,27 @@
-import { ethers } from "ethers";
+import { ethers } from 'ethers'
 
 export async function createSalt(signer: ethers.Signer) {
-  let blockNumber = await signer.provider?.getBlockNumber();
+  let blockNumber = await signer.provider?.getBlockNumber()
 
   if (!blockNumber) {
-    blockNumber = Math.floor(Math.random() * 100000000);
+    blockNumber = Math.floor(Math.random() * 100000000)
   }
 
-  const timestamp = Math.floor(Date.now() / 1000);
+  const timestamp = Math.floor(Date.now() / 1000)
 
-  const hash = ethers.utils.keccak256(ethers.utils.concat([ethers.BigNumber.from(timestamp).toHexString(), ethers.BigNumber.from(blockNumber).toHexString(), ethers.utils.hexlify(ethers.utils.randomBytes(12))]));
+  const hash = ethers.utils.keccak256(
+    ethers.utils.concat([
+      ethers.BigNumber.from(timestamp).toHexString(),
+      ethers.BigNumber.from(blockNumber).toHexString(),
+      ethers.utils.hexlify(ethers.utils.randomBytes(12)),
+    ])
+  )
 
-  console.log("hash", hash);
+  console.log('hash', hash)
 
-  const splice = ethers.utils.hexDataSlice(hash, 0, 12);
+  const splice = ethers.utils.hexDataSlice(hash, 0, 12)
 
-  console.log("splice", splice);
+  console.log('splice', splice)
 
-  return ethers.utils.hexZeroPad(splice, 32);
+  return ethers.utils.hexZeroPad(splice, 32)
 }

--- a/apps/erc20-delegatable-app/lib/utils/create-salt.ts
+++ b/apps/erc20-delegatable-app/lib/utils/create-salt.ts
@@ -1,0 +1,21 @@
+import { ethers } from "ethers";
+
+export async function createSalt(signer: ethers.Signer) {
+  let blockNumber = await signer.provider?.getBlockNumber();
+
+  if (!blockNumber) {
+    blockNumber = Math.floor(Math.random() * 100000000);
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  const hash = ethers.utils.keccak256(ethers.utils.concat([ethers.BigNumber.from(timestamp).toHexString(), ethers.BigNumber.from(blockNumber).toHexString(), ethers.utils.hexlify(ethers.utils.randomBytes(12))]));
+
+  console.log("hash", hash);
+
+  const splice = ethers.utils.hexDataSlice(hash, 0, 12);
+
+  console.log("splice", splice);
+
+  return ethers.utils.hexZeroPad(splice, 32);
+}

--- a/apps/erc20-delegatable-sol/package.json
+++ b/apps/erc20-delegatable-sol/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "clean": "rm -rf cache/ artifacts/",
     "compile": "hardhat --show-stack-traces --max-memory 8192 compile",
+    "console": "hardhat console --network",
     "coverage": "HIDE_DEPLOY_LOG=true OPTIMIZER_DISABLED=true hardhat coverage",
     "chain": "hardhat node --network hardhat",
     "chain:fork": "FORK_ENABLED=true hardhat node --network hardhat",


### PR DESCRIPTION
This is needed for users to issue multiple delegation to the same address, with the same amount, with the same enforcers.

Adding the salt to the required enforcer, `ERC20FromAllowanceEnforcer`, generates a unique delegation signature that wont conflict with the `spentMap`